### PR TITLE
Remove step to copy tools.jar from java21 installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,26 @@
+# Based on quay.io/semoss/docker-tomcat:ubi8-rhel
 #docker build . -t quay.io/semoss/docker:ubi8-rhel
 
 ARG BASE_REGISTRY=quay.io
 ARG BASE_IMAGE=semoss/docker-tomcat
 ARG BASE_TAG=ubi8-rhel
 
-FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} as base
+# JAVA, JDK and TOMCAT default versions
+ARG AZUL_ZULU_VERSION=21.42.19
+ARG JAVA_HOME=/usr/lib/jvm/zulu21
+ARG JDK_VERSION=21.0.7
+ARG TOMCAT_VERSION=9.0.107
+ARG MAVEN_HOME=/opt/apache-maven-3.8.5
 
-FROM base as mavenpuller
+FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS base
+
+FROM base AS mavenpuller
+# Tomcat  
+ARG TOMCAT_VERSION
+ARG TOMCAT_HOME=/opt/apache-tomcat-${TOMCAT_VERSION}
+
+ENV TOMCAT_VERSION=${TOMCAT_VERSION}
+ENV TOMCAT_HOME=${TOMCAT_HOME}
 
 RUN yum install -y curl lsof \
 	&& mkdir /opt/semosshome \
@@ -15,12 +29,29 @@ RUN yum install -y curl lsof \
 	&& /opt/semoss-artifacts/artifacts/scripts/update_latest_dev.sh \
 	&& chmod 777 /opt/semosshome/config/Chromedriver/*
 
-FROM base as intermediate
+FROM base AS intermediate
 
 LABEL maintainer="semoss@semoss.org"
 
 ENV PATH=$PATH:/opt/semoss-artifacts/artifacts/scripts
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib:$R_LIBS_SITE/rJava/jri
+
+# Tomcat and Maven 
+ARG TOMCAT_VERSION
+ARG TOMCAT_HOME=/opt/apache-tomcat-${TOMCAT_VERSION}
+
+# JAVA arguments
+ARG AZUL_ZULU_VERSION
+ARG JAVA_HOME
+ARG JDK_VERSION
+
+#JAVA env values for install_java.sh
+ENV AZUL_ZULU_VERSION=${AZUL_ZULU_VERSION}
+ENV JDK_VERSION=${JDK_VERSION}
+
+ENV TOMCAT_VERSION=${TOMCAT_VERSION}
+ENV TOMCAT_HOME=${TOMCAT_HOME}
+ENV JAVA_HOME=${JAVA_HOME}
 
 RUN wget https://downloads.rclone.org/v1.64.2/rclone-v1.64.2-linux-amd64.rpm \
 	&& yum install -y rclone-v1.64.2-linux-amd64.rpm\
@@ -30,8 +61,14 @@ RUN wget https://downloads.rclone.org/v1.64.2/rclone-v1.64.2-linux-amd64.rpm \
 	&& mkdir $TOMCAT_HOME/webapps/Monolith \
 	&& mkdir $TOMCAT_HOME/webapps/SemossWeb \
 	&& echo "export LD_PRELOAD=/usr/lib64/libpython3.9.so" >> $TOMCAT_HOME/bin/setenv.sh \
-	&& cp $JAVA_HOME/lib/tools.jar $TOMCAT_HOME/lib \
-	&& sed -i "s/tomcat.util.scan.StandardJarScanFilter.jarsToSkip=/tomcat.util.scan.StandardJarScanFilter.jarsToSkip=*.jar,/g" $TOMCAT_HOME/conf/catalina.properties; 
+	&& echo FILES=$(ls -als $TOMCAT_HOME/) echo "FILES=$FILES" > files_in_tomcatHome.txt \
+	&& cat files_in_tomcatHome.txt \
+	&& echo FILES=$(ls -als $TOMCAT_HOME/conf/) echo "FILES=$FILES" > files_in_tomcatHome.txt \
+    && cat files_in_tomcatHome.txt \
+	&& sed -i "s/tomcat.util.scan.StandardJarScanFilter.jarsToSkip=/tomcat.util.scan.StandardJarScanFilter.jarsToSkip=*.jar,/g" $TOMCAT_HOME/conf/catalina.properties;
+	# Removing step to copy JAVA_HOME/lib/tools.jar since this is not present in ZULU java 21
+	# && cp $JAVA_HOME/lib/tools.jar $TOMCAT_HOME/lib \
+	
 
 RUN cd /opt && git clone https://github.com/SEMOSS/semoss-artifacts \
 	&& chmod 777 /opt/semoss-artifacts/artifacts/scripts/*.sh
@@ -45,8 +82,17 @@ COPY --from=mavenpuller /opt/semoss-artifacts/ver.txt /opt/semoss-artifacts/ver.
 
 FROM scratch AS final
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu8
-ENV TOMCAT_HOME=/opt/apache-tomcat-9.0.102
+# Tomcat arguments 
+ARG TOMCAT_VERSION 
+ARG TOMCAT_HOME=/opt/apache-tomcat-${TOMCAT_VERSION} 
+
+# JAVA arguments
+ARG JAVA_HOME 
+
+ENV TOMCAT_VERSION=${TOMCAT_VERSION} 
+ENV TOMCAT_HOME=${TOMCAT_HOME} 
+ENV JAVA_HOME=${JAVA_HOME} 
+
 ENV MAVEN_HOME=/opt/apache-maven-3.8.5
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/python3.9/dist-packages/jep
 ENV PATH=$PATH:${MAVEN_HOME}/bin:${TOMCAT_HOME}/bin:${JAVA_HOME}/bin:/usr/lib/R/bin::/usr/lib/R/pandoc-2.17.1.1/bin:/opt/semoss-artifacts/artifacts/scripts


### PR DESCRIPTION
## Description
Updates java to java 21 and tomcat to version 9.0.107 using Docker arguments. Removed step to copy a file called zulu8/lib/tools.jar since it is no longer present in zulu21/lib

## Changes Made
Change Java and tomcat versions to arguments passed at image build time.
Remove "cp $JAVA_HOME/lib/tools.jar $TOMCAT_HOME/lib" step from Dockerfile that was used to copy the $JAVA_HOME/lib/tools.jar since this is not present in ZULU java 21

## How to Test
<!-- Explain how reviewers can test your changes -->
1.- Change the java/tomcat version using docker build's "build-arg" flag:
``` 
docker build --no-cache  --build-arg TOMCAT_VERSION=9.0.102 \
    --build-arg AZUL_ZULU_VERSION=21.42.19 \  
    -t quay.io/semoss/docker:ubi8-rhel -f Dockerfile .
```
2.- Image will be built with the specified java and tomcat values

## Notes
<!-- Any further notes regarding changes -->